### PR TITLE
Upgrade dependencies, add CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: test
+
+on:
+  push:
+    branches:  [ '**' ]
+
+jobs:
+  main:
+    name: main
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04 ]
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: '3.8'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          make install
+
+      - name: Test with pytest
+        run: |
+          make test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
+click==8.1.7
+Jinja2==3.1.2
+pandas==2.0.3
+great-expectations==0.18.6
 
-Click
-jinja2
-pandas
-great_expectations
 # Testing Dependencies
-pytest
+pytest==7.4.3
 
 # Documentation Dependencies
-sphinx
-sphinxcontrib-apidoc
+Sphinx==7.1.2
+sphinxcontrib-apidoc==0.4.0


### PR DESCRIPTION
Already compatible with Python 3.8, just bump deps and add GitHub CI.