### PR TITLE
Have a better profile-agnostic report introduction

### DIFF
--- a/dqgen/resources/html_templates/main.jinja2
+++ b/dqgen/resources/html_templates/main.jinja2
@@ -4,7 +4,7 @@
 {% block content %}
 {% endraw %}
     <p>This report is automatically generated from the {% raw %}{{ conf.dataset_name }}{% endraw %} RDF dataset on <time>{% raw %}{{ conf.timestamp }}{% endraw %}</time>
-        and aims at presenting the difference between two versions of an authority table following {% raw %}{{ conf.application_profile }}{% endraw %} application profile.</p>
+        and aims at presenting the difference between two versions of an RDFS/OWL vocabulary following the {% raw %}{{ conf.application_profile }}{% endraw %} application profile.</p>
     <p>Report details</p>
     <p><strong>Dataset used: </strong> {% raw %}{{ conf.dataset_name }}{% endraw %}</p>
     <p><strong>Time: </strong> {% raw %}{{ conf.timestamp }}{% endraw %}</p>


### PR DESCRIPTION
The "authority table" (AT) may have been mission-specific wording for a specific time, but it is no longer relevant. The European Union's ATs are indeed encoded as SKOS vocabularies, so that's what we can call them, with the assumption that our tool can diff other SKOS vocabs as well. Same goes for RDFS/OWL (we put a slash to indicate it can be any subset of pure RDFS and OWL) and ShACL shapes.