### PR TITLE
Fix deletion queries returning all values

### DIFF
--- a/dqgen/resources/query_templates/count_property_deletions.rq
+++ b/dqgen/resources/query_templates/count_property_deletions.rq
@@ -69,12 +69,12 @@ WHERE {
   }
   # get all deleted property values
   GRAPH ?deletionsGraph {
-    ?instance ?property [] .
+    ?instance ?property ?value .
   }
   # ... which were not attached to some (other) instance now
   FILTER NOT EXISTS {
     GRAPH ?insertionsGraph {
-     ?instance ?property [] .
+     ?instance ?property ?value .
     }
   }
   GRAPH ?oldVersionGraph {

--- a/dqgen/resources/query_templates/count_reified_properties_deletions.rq
+++ b/dqgen/resources/query_templates/count_reified_properties_deletions.rq
@@ -71,13 +71,13 @@ WHERE {
    # get all deleted reified structures
   GRAPH ?deletionsGraph {
     ?instance ?property ?object .
-    ?object ?objProperty [] .
+    ?object ?objProperty ?value .
   }
   # ... which were not attached to some (other) instance now
   FILTER NOT EXISTS {
     GRAPH ?insertionsGraph {
       ?instance ?property ?object .
-      ?object ?objProperty [].
+      ?object ?objProperty ?value .
     }
   }
     FILTER NOT EXISTS {

--- a/dqgen/resources/query_templates/property_deletions.rq
+++ b/dqgen/resources/query_templates/property_deletions.rq
@@ -69,12 +69,12 @@ WHERE {
   }
   # get all deleted property values
   GRAPH ?deletionsGraph {
-    ?instance ?property [] .
+    ?instance ?property ?value .
   }
   # ... which were not attached to some (other) instance now
   FILTER NOT EXISTS {
     GRAPH ?insertionsGraph {
-     ?instance ?property [] .
+     ?instance ?property ?value .
     }
   }
   GRAPH ?oldVersionGraph {

--- a/dqgen/resources/query_templates/reified_properties_deletions.rq
+++ b/dqgen/resources/query_templates/reified_properties_deletions.rq
@@ -71,13 +71,13 @@ WHERE {
    # get all deleted reified structures
   GRAPH ?deletionsGraph {
     ?instance ?property ?object .
-    ?object ?objProperty [] .
+    ?object ?objProperty ?value .
   }
   # ... which were not attached to some (other) instance now
   FILTER NOT EXISTS {
     GRAPH ?insertionsGraph {
       ?instance ?property ?object .
-      ?object ?objProperty [].
+      ?object ?objProperty ?value .
     }
   }
     FILTER NOT EXISTS {


### PR DESCRIPTION
When the deletions graph contains deleted properties that have multiple values, ALL of those values are returned in the deletion queries, instead of just the ones that were deleted.

It turns out that in the deletion BGPs the values are always unbound because of the anonymous variable `[]`. This brings in all values when the final BGP for returning optional labels matches on all of them, because of this loose binding.

In order to avoid this, simply use the named variable that is already used in the last BGP. Doing this should have no side-effects.