### PR TITLE
Change dependency locking strategy, add Python 3.8-3.12+ compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,12 @@
-click==8.1.7
-Jinja2==3.1.2
-pandas==2.0.3
-great-expectations==0.18.6
+click==8.*
+Jinja2==3.*
+pandas==2.*
+numpy>=1.24,<2
+great-expectations==0.18.22
 
 # Testing Dependencies
-pytest==7.4.3
+pytest==8.*
 
 # Documentation Dependencies
-Sphinx==7.1.2
-sphinxcontrib-apidoc==0.4.0
+Sphinx==7.*
+sphinxcontrib-apidoc~=0.5.0


### PR DESCRIPTION
Change the dependency version locking strategy to be loose in some cases
and strict in others. Where the major version is 0, the compatible
(minor) version is locked.

Otherwise, with some exceptions, only the major version need be locked.
One such exception is Great Expectations, which in v1 changed its
API/ABI, namely in relation to Pandas (interestingly the latest version
1.4.2 requires a lower Pandas version 2.1.3 but the older one will work
with the latest Pandas 2.2.3).

For Python compatibility from v3.8 (or possibly lower but untested) up
to v3.12 (and possibly beyond but untested), the explicit minimum NumPy
version is specified with a major version ceiling. This allows for lower
Python versions to be used, and not trip up on the NumPy being also of a
lower version when upgrading.

The Sphinx version can be upgraded to v8.x if using Python 3.10+.