### PR TITLE
Fix property object value changes missed due to language filter

### DIFF
--- a/dqgen/resources/query_templates/count_property_value_updates.rq
+++ b/dqgen/resources/query_templates/count_property_value_updates.rq
@@ -99,8 +99,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/dqgen/resources/query_templates/count_reified_property_value_updates.rq
+++ b/dqgen/resources/query_templates/count_reified_property_value_updates.rq
@@ -103,7 +103,15 @@ WHERE {
         ?object ?objProperty ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?newValue) = lang(?oldValue) && ?newValue != ?oldValue )
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/dqgen/resources/query_templates/property_value_updates.rq
+++ b/dqgen/resources/query_templates/property_value_updates.rq
@@ -156,8 +156,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/dqgen/resources/query_templates/reified_property_value_updates.rq
+++ b/dqgen/resources/query_templates/reified_property_value_updates.rq
@@ -159,7 +159,15 @@ WHERE {
         ?object ?objProperty ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?newValue) = lang(?oldValue) && ?newValue != ?oldValue )
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/tests/test_data/rdfs/dsA/test_queries/value_update_property_concept_alt_label.rq
+++ b/tests/test_data/rdfs/dsA/test_queries/value_update_property_concept_alt_label.rq
@@ -37,7 +37,7 @@ PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 #
 # Show all properties value updates
 #
-SELECT DISTINCT ?instance (?prefLabel as ?instanceLabel) ?property (?old_value AS ?initialValue) (?value AS ?updatedValue)
+SELECT DISTINCT ?instance (?prefLabel as ?instanceLabel) ?property (?oldValue AS ?initialValue) (?newValue AS ?updatedValue)
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters
@@ -72,7 +72,7 @@ WHERE {
   # get all property and values
   GRAPH ?newVersionGraph {
     ?instance a ?class .
-    ?instance ?property ?value .
+    ?instance ?property ?newValue .
     optional {
       ?instance skos:prefLabel ?prefLabel .
       #restrict prefLabel to a certain language
@@ -81,19 +81,26 @@ WHERE {
   }
   # ... which were attached to some (other) instance before and had another value
   GRAPH ?oldVersionGraph {
-      ?instance ?property ?old_value .
+      ?instance ?property ?oldValue .
   }
   # the old value shall be deleted
   GRAPH ?deletionsGraph {
-      ?instance ?property ?old_value .
+      ?instance ?property ?oldValue .
     }
   # the new value shall be inserted
   GRAPH ?insertionsGraph {
-      ?instance ?property ?value .
+      ?instance ?property ?newValue .
    }
-  # the language tag shall be the same
-
-  FILTER( lang(?old_value) = lang(?value) && ?old_value != ?value )
-
+  # handle both language-tagged literals and non-language-tagged values
+  FILTER(
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
-ORDER BY ?instance ?value
+ORDER BY ?instance ?newValue

--- a/tests/test_data/rdfs/dsA/test_queries/value_update_property_concept_notation.rq
+++ b/tests/test_data/rdfs/dsA/test_queries/value_update_property_concept_notation.rq
@@ -37,7 +37,7 @@ PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 #
 # Show all properties value updates
 #
-SELECT DISTINCT ?instance (?prefLabel as ?instanceLabel) ?property (?old_value AS ?initialValue) (?value AS ?updatedValue)
+SELECT DISTINCT ?instance (?prefLabel as ?instanceLabel) ?property (?oldValue AS ?initialValue) (?newValue AS ?updatedValue)
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters
@@ -72,7 +72,7 @@ WHERE {
   # get all property and values
   GRAPH ?newVersionGraph {
     ?instance a ?class .
-    ?instance ?property ?value .
+    ?instance ?property ?newValue .
     optional {
       ?instance skos:prefLabel ?prefLabel .
       #restrict prefLabel to a certain language
@@ -81,19 +81,26 @@ WHERE {
   }
   # ... which were attached to some (other) instance before and had another value
   GRAPH ?oldVersionGraph {
-      ?instance ?property ?old_value .
+      ?instance ?property ?oldValue .
   }
   # the old value shall be deleted
   GRAPH ?deletionsGraph {
-      ?instance ?property ?old_value .
+      ?instance ?property ?oldValue .
     }
   # the new value shall be inserted
   GRAPH ?insertionsGraph {
-      ?instance ?property ?value .
+      ?instance ?property ?newValue .
    }
-  # the language tag shall be the same
-
-  FILTER( lang(?old_value) = lang(?value) && ?old_value != ?value )
-
+  # handle both language-tagged literals and non-language-tagged values
+  FILTER(
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
-ORDER BY ?instance ?value
+ORDER BY ?instance ?newValue

--- a/tests/test_data/rdfs/dsB/test_queries/value_update_reified_concept_alt_label_literal_form.rq
+++ b/tests/test_data/rdfs/dsB/test_queries/value_update_reified_concept_alt_label_literal_form.rq
@@ -37,7 +37,7 @@ PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 #
 # Show reified structures updated values
 #
-SELECT DISTINCT ?instance (?prefLabel as ?instanceLabel) ?property ?objProperty (?value AS ?oldValue) ?newValue
+SELECT DISTINCT ?instance (?prefLabel as ?instanceLabel) ?property ?objProperty (?oldValue AS ?initialValue) (?newValue AS ?updatedValue)
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters
@@ -70,7 +70,7 @@ WHERE {
     ?insertions a sh:SchemeDeltaInsertions ;
       sh:usingNamedGraph/sd:name ?insertionsGraph .
   }
- # get all reified structures values
+  # get all reified structures values
   GRAPH ?newVersionGraph {
     ?instance a ?class .
     ?instance ?property ?object .
@@ -83,20 +83,27 @@ WHERE {
   }
   # ... which were attached to some (other) instance before and had another value
   GRAPH ?oldVersionGraph {
-        ?instance ?property ?object .
-        ?object ?objProperty ?value .
+    ?instance ?property ?object .
+    ?object ?objProperty ?oldValue .
   }
   # the old value shall be deleted
   GRAPH ?deletionsGraph {
-        ?object ?objProperty ?value .
-    }
+    ?object ?objProperty ?oldValue .
+  }
   # the new value shall be inserted
   GRAPH ?insertionsGraph {
-
-        ?object ?objProperty ?newValue .
-   }
-  # the language tag shall be the same
-
-  FILTER( lang(?newValue) = lang(?value) && ?newValue != ?value )
+    ?object ?objProperty ?newValue .
+  }
+  # handle both language-tagged literals and non-language-tagged values
+  FILTER(
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance ?newValue

--- a/tests/test_data/rdfs/dsB/test_queries/value_update_reified_concept_pref_label_literal_form.rq
+++ b/tests/test_data/rdfs/dsB/test_queries/value_update_reified_concept_pref_label_literal_form.rq
@@ -37,7 +37,7 @@ PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 #
 # Show reified structures updated values
 #
-SELECT DISTINCT ?instance (?prefLabel as ?instanceLabel) ?property ?objProperty (?value AS ?oldValue) ?newValue
+SELECT DISTINCT ?instance (?prefLabel as ?instanceLabel) ?property ?objProperty (?oldValue AS ?initialValue) (?newValue AS ?updatedValue)
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters
@@ -70,7 +70,7 @@ WHERE {
     ?insertions a sh:SchemeDeltaInsertions ;
       sh:usingNamedGraph/sd:name ?insertionsGraph .
   }
- # get all reified structures values
+  # get all reified structures values
   GRAPH ?newVersionGraph {
     ?instance a ?class .
     ?instance ?property ?object .
@@ -83,20 +83,27 @@ WHERE {
   }
   # ... which were attached to some (other) instance before and had another value
   GRAPH ?oldVersionGraph {
-        ?instance ?property ?object .
-        ?object ?objProperty ?value .
+    ?instance ?property ?object .
+    ?object ?objProperty ?oldValue .
   }
   # the old value shall be deleted
   GRAPH ?deletionsGraph {
-        ?object ?objProperty ?value .
-    }
+    ?object ?objProperty ?oldValue .
+  }
   # the new value shall be inserted
   GRAPH ?insertionsGraph {
-
-        ?object ?objProperty ?newValue .
-   }
-  # the language tag shall be the same
-
-  FILTER( lang(?newValue) = lang(?value) && ?newValue != ?value )
+    ?object ?objProperty ?newValue .
+  }
+  # handle both language-tagged literals and non-language-tagged values
+  FILTER(
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance ?newValue


### PR DESCRIPTION
Ever since adding support for the OWL Core profile, in particular semantic properties like `rdfs:domain` and `rdfs:range`, it has gone unnoticed that changes related to these properties do not come up. This was because in the corresponding queries there was a filter to check if the language is the same for both the old and new data.

A more intricate query has been put in place in order to cater for when there is no scope for such language tags to exist. However, it is not known at this time why this is required in the first place. It needs to be checked what is in fact the effect of having a different language tag, or no language tag to a language tag, and vice-versa.