### PR TITLE
Automate some customizations related to printing, prefixes

### DIFF
--- a/dqgen/resources/html_templates/main.jinja2
+++ b/dqgen/resources/html_templates/main.jinja2
@@ -32,5 +32,9 @@
     {% endfor %}
 {% endfor %}
 {% raw %}
+    <h1>Prefixes</h1>
+    <section class="ui basic segment">
+    {{ mc.render_namespaces(namespaces.namespaces_as_dict()) }}
+    </section>
 {% endblock %}
 {% endraw %}

--- a/dqgen/resources/html_templates/static/layout.html
+++ b/dqgen/resources/html_templates/static/layout.html
@@ -48,6 +48,10 @@
             margin: revert !important;
         }
 
+        #printButton{
+            float: right;
+            margin-top: 0.5em;
+        }
 
         @media print {
             #toc {
@@ -55,7 +59,7 @@
             }
 
             #print-container {
-                width: 90% !important;
+                width: 100% !important;
                 position: absolute;
                 left: 0;
                 top: 0;
@@ -64,6 +68,13 @@
             footer {
                 display: none;
             }
+            #printButton {
+                visibility: hidden;
+            }
+            .dataTables_length, .dataTables_filter, .dt-buttons {
+                visibility: hidden !important;
+            }
+            @page {size: landscape !important}
         }
 
     </style>
@@ -74,7 +85,9 @@
     <div class="three wide column">
         <div id="toc"></div>
     </div>
+
     <div id="print-container" class="ten wide column">
+        <button class="ui button" id="printButton">Print report</button>
         <h1 class="ui header center aligned reportTitle" id="skip-toc">{{ conf.title }}</h1>
         {% block content %}
             < empty >
@@ -131,7 +144,7 @@
                 $(this).next().remove()
                 $(this).remove();
             });
-            $("#print-container").append("<p><strong>Datasets are identical and no differences were found</strong></p>")
+            $("#print-container").append("<p><strong>Datasets are identical and no difference was found</strong></p>")
         }
 
         $(function () {
@@ -144,6 +157,13 @@
                 highlightDefault: "true"
             });
         });
+
+        $(function () {
+            $("#printButton").click(function () {
+                $("table.display").DataTable().page.len(-1).draw()
+                window.print()
+            })
+        })
 
 
     });

--- a/dqgen/resources/html_templates/static/macros.html
+++ b/dqgen/resources/html_templates/static/macros.html
@@ -27,6 +27,7 @@
 
 {% macro pandas_table(df, caption, column_labels={}) -%}
     {% if (df is defined) and (df is not none) %}
+                {% set df = df.fillna(value="") %}
         <table class="display">
             <thead class="center aligned">
             <tr>
@@ -69,4 +70,24 @@
         {% endfor %}
 
     {% endfor %}
+{% endmacro %}
+
+{% macro render_namespaces(namesapces_dist) %}
+    <table class="display">
+        <thead class="center aligned">
+        <tr>
+            <th>Namespace</th>
+            <th>URI</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for prefix, uri in namesapces_dist|dictsort %}
+            <tr>
+                <td>{{ prefix }}</td>
+                <td>{{ uri }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+        <caption>Prefixes</caption>
+    </table>
 {% endmacro %}


### PR DESCRIPTION
These customizations were previously applied manually in the differ, see for e.g. meaningfy-ws/rdf-differ-ws#100. They add proper printing functionality and a table of namespace and prefix mappings. Automating this saves the headache of reapplying them following the patching approach.