### PR TITLE
Remove crude section name pluralization

### DIFF
--- a/dqgen/resources/html_templates/property.jinja2
+++ b/dqgen/resources/html_templates/property.jinja2
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     {% endraw %}
-<h3 class="ui header">{{ operation|title }} {{ property_name }}s</h3>
+<h3 class="ui header">{{ operation|title }} {{ property_name }}</h3>
 <section class="ui basic segment">
     <p>The table below lists the {{ operation }} <strong>{{ property }}</strong>
     </p>


### PR DESCRIPTION
There is no need to add an `s` and make things more confusing, as that's now how pluralization works for all English words.