### PR TITLE
Queries: Remove or rename some result columns

### DIFF
--- a/dqgen/resources/asciidoc_templates/statistics.jinja2
+++ b/dqgen/resources/asciidoc_templates/statistics.jinja2
@@ -27,7 +27,7 @@
 
 [cols="1,1,1,1,1,1,1", options="header"]
 |===
-|Property group
+|Category
 |Property
 |Added
 |Deleted

--- a/dqgen/resources/html_templates/statistics.jinja2
+++ b/dqgen/resources/html_templates/statistics.jinja2
@@ -36,7 +36,7 @@
         <table class="display">
             <thead class="center aligned">
             <tr>
-                <th>Property group</th>
+                <th>Category</th>
                 <th>Property</th>
                 <th>Added</th>
                 <th>Deleted</th>

--- a/dqgen/resources/query_templates/instance_additions.rq
+++ b/dqgen/resources/query_templates/instance_additions.rq
@@ -37,9 +37,9 @@ PREFIX sh: <http://purl.org/skos-history/>
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 # identify added instances
 {% if cls == "owl:ObjectProperty" or cls == "owl:DatatypeProperty" %}
-SELECT distinct ?class ?instance ?prefLabel ?prefLabelLang ?domain ?range ?minCardinality ?maxCardinality ("{{type_of_action}}" as ?actionType)
+SELECT DISTINCT (?instance AS ?resource) (?prefLabel as ?label) (?prefLabelLang AS ?labelLang) ?domain ?range ?minCardinality ?maxCardinality
 {% else %}
-SELECT distinct ?class ?instance ?prefLabel ?prefLabelLang ("{{type_of_action}}" as ?actionType)
+SELECT DISTINCT (?instance AS ?resource) (?prefLabel as ?label) (?prefLabelLang AS ?labelLang)
 {% endif %}
 WHERE {
   GRAPH ?versionHistoryGraph {

--- a/dqgen/resources/query_templates/instance_deletions.rq
+++ b/dqgen/resources/query_templates/instance_deletions.rq
@@ -42,7 +42,7 @@ PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 # as bad practice, because they still may be referenced elsewhere.
 # Cosider using owl:deprecated instead)
 
-SELECT distinct ?class ?instance ?prefLabel ?prefLabelLang ("{{type_of_action}}" as ?actionType)
+SELECT DISTINCT (?instance AS ?resource) (?prefLabel as ?label) (?prefLabelLang AS ?labelLang)
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters

--- a/dqgen/resources/query_templates/movement_cross_instance.rq
+++ b/dqgen/resources/query_templates/movement_cross_instance.rq
@@ -27,9 +27,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX shacl: <http://www.w3.org/ns/shacl#>
 
 # Show all movements cross instances
-SELECT DISTINCT ?oldInstance ?class ?oldInstancePrefLabel ?oldInstancePrefLabelLang ?newInstance
-    ?newInstancePrefLabel
-    ?newInstancePrefLabelLang ?property ?value ?valueLang ("{{type_of_action}}" as ?actionType)
+SELECT DISTINCT 
+    (?oldInstance AS ?oldResource) (?oldInstancePrefLabel AS ?oldResourceLabel) (?oldInstancePrefLabelLang AS ?oldResourceLabelLang)
+    (?newInstance AS ?newResource) (?newInstancePrefLabel AS ?newResourceLabel) (?newInstancePrefLabelLang AS ?newResourceLabelLang)
+    ?property ?value ?valueLang
 WHERE {
           GRAPH ?versionHistoryGraph {
     # parameters

--- a/dqgen/resources/query_templates/movement_cross_property.rq
+++ b/dqgen/resources/query_templates/movement_cross_property.rq
@@ -27,7 +27,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX shacl: <http://www.w3.org/ns/shacl#>
 
 # Show all movements cross property
-SELECT DISTINCT ?instance ?class ?prefLabel ?prefLabelLang ?oldProperty ?newProperty ?value ?valueLang ("{{type_of_action}}" as ?actionType)
+SELECT DISTINCT (?instance AS ?resource) (?prefLabel as ?label) (?prefLabelLang AS ?labelLang) ?oldProperty ?newProperty ?value ?valueLang
 WHERE {
           GRAPH ?versionHistoryGraph {
     # parameters

--- a/dqgen/resources/query_templates/property_additions.rq
+++ b/dqgen/resources/query_templates/property_additions.rq
@@ -37,7 +37,7 @@ PREFIX sh: <http://purl.org/skos-history/>
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 
 # Show all added instance/property
-SELECT DISTINCT ?instance ?class ?prefLabel ?prefLabelLang ?property ?value ?valueLang ("{{type_of_action}}" as ?actionType)
+SELECT DISTINCT (?instance AS ?resource) (?prefLabel as ?label) (?prefLabelLang AS ?labelLang) ?property ?value ?valueLang
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters

--- a/dqgen/resources/query_templates/property_deletions.rq
+++ b/dqgen/resources/query_templates/property_deletions.rq
@@ -36,7 +36,7 @@ PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
 PREFIX sh: <http://purl.org/skos-history/>
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 # Show all deleted instance/property
-SELECT DISTINCT ?instance ?class ?prefLabel ?prefLabelLang ?property ?value ?valueLang ("{{type_of_action}}" as ?actionType)
+SELECT DISTINCT (?instance AS ?resource) (?prefLabel as ?label) (?prefLabelLang AS ?labelLang) ?property ?value ?valueLang
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters

--- a/dqgen/resources/query_templates/property_value_updates.rq
+++ b/dqgen/resources/query_templates/property_value_updates.rq
@@ -37,8 +37,7 @@ PREFIX sh: <http://purl.org/skos-history/>
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 
 # Show all properties value updates
-SELECT DISTINCT ?instance ?class ?prefLabel ?prefLabelLang ?property ?oldValue ?oldValueLang ?newValue ?newValueLang
-  ("{{type_of_action}}" as ?actionType)
+SELECT DISTINCT (?instance AS ?resource) (?prefLabel as ?label) (?prefLabelLang AS ?labelLang) ?property ?oldValue ?oldValueLang ?newValue ?newValueLang
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters

--- a/dqgen/resources/query_templates/reified_movement_cross_instance.rq
+++ b/dqgen/resources/query_templates/reified_movement_cross_instance.rq
@@ -37,8 +37,10 @@ PREFIX sh: <http://purl.org/skos-history/>
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 
 # Show all movements cross instance for reified structures
-SELECT DISTINCT ?oldInstance ?class ?oldInstancePrefLabel ?oldInstancePrefLabelLang ?newInstance ?newInstancePrefLabel
-  ?newInstancePrefLabelLang ?property ?object ?objProperty ?value ?valueLang ("{{type_of_action}}" as ?actionType)
+SELECT DISTINCT
+  (?oldInstance AS ?oldResource) (?oldInstancePrefLabel AS ?oldResourceLabel) (?oldInstancePrefLabelLang AS ?oldResourceLabelLang)
+  (?newInstance AS ?newResource) (?newInstancePrefLabel AS ?newResourceLabel) (?newInstancePrefLabelLang AS ?newResourceLabelLang)
+  ?property ?object ?objProperty ?value ?valueLang
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters

--- a/dqgen/resources/query_templates/reified_movement_cross_property.rq
+++ b/dqgen/resources/query_templates/reified_movement_cross_property.rq
@@ -37,8 +37,7 @@ PREFIX sh: <http://purl.org/skos-history/>
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 
 # Show all movements cross reified properties
-SELECT DISTINCT ?instance ?class ?prefLabel ?prefLabelLang ?oldProperty ?oldObject ?newProperty ?newObject ?objProperty
-  ?value ?valueLang ("{{type_of_action}}" as ?actionType)
+SELECT DISTINCT (?instance AS ?resource) (?prefLabel as ?label) (?prefLabelLang AS ?labelLang) ?oldProperty ?oldObject ?newProperty ?newObject ?objProperty ?value ?valueLang
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters

--- a/dqgen/resources/query_templates/reified_properties_additions.rq
+++ b/dqgen/resources/query_templates/reified_properties_additions.rq
@@ -37,7 +37,7 @@ PREFIX sh: <http://purl.org/skos-history/>
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 
 # Show all added reified structures
-SELECT DISTINCT ?instance ?class ?prefLabel ?prefLabelLang ?property ?object ?objProperty ?value ?valueLang ("{{type_of_action}}" as ?actionType)
+SELECT DISTINCT (?instance AS ?resource) (?prefLabel as ?label) (?prefLabelLang AS ?labelLang) ?property ?object ?objProperty ?value ?valueLang
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters

--- a/dqgen/resources/query_templates/reified_properties_deletions.rq
+++ b/dqgen/resources/query_templates/reified_properties_deletions.rq
@@ -36,7 +36,7 @@ PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
 PREFIX sh: <http://purl.org/skos-history/>
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 # Show all deleted reified structures
-SELECT DISTINCT ?instance ?class ?prefLabel ?prefLabelLang ?property ?object ?objProperty ?value ?valueLang ("{{type_of_action}}" as ?actionType)
+SELECT DISTINCT (?instance AS ?resource) (?prefLabel as ?label) (?prefLabelLang AS ?labelLang) ?property ?object ?objProperty ?value ?valueLang
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters

--- a/dqgen/resources/query_templates/reified_property_value_updates.rq
+++ b/dqgen/resources/query_templates/reified_property_value_updates.rq
@@ -37,7 +37,7 @@ PREFIX sh: <http://purl.org/skos-history/>
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 
 # Show reified structures updated values
-SELECT DISTINCT ?instance ?class ?prefLabel ?prefLabelLang ?property ?object ?objProperty ?oldValue ?oldValueLang ?newValue ?newValueLang ("{{type_of_action}}" as ?actionType)
+SELECT DISTINCT (?instance AS ?resource) (?prefLabel as ?label) (?prefLabelLang AS ?labelLang) ?property ?object ?objProperty ?oldValue ?oldValueLang ?newValue ?newValueLang
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters

--- a/tests/test_data/rdfs/dsA/test_queries/added_instance_concept.rq
+++ b/tests/test_data/rdfs/dsA/test_queries/added_instance_concept.rq
@@ -36,7 +36,7 @@ PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 #
 # identify added instances
 #
-SELECT distinct ?class (?instance AS ?addedInstance) (?prefLabel AS ?addedInstanceLabel)
+SELECT distinct (?instance AS ?addedInstance) (?prefLabel AS ?addedInstanceLabel)
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters

--- a/tests/test_data/rdfs/dsA/test_queries/deleted_instance_concept.rq
+++ b/tests/test_data/rdfs/dsA/test_queries/deleted_instance_concept.rq
@@ -40,7 +40,7 @@ PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 # as bad practice, because they still may be referenced elsewhere.
 # Cosider using owl:deprecated instead)
 #
-SELECT distinct ?class (?instance AS ?deletedInstance) (?prefLabel AS ?deletedInstanceLabel)
+SELECT distinct (?instance AS ?deletedInstance) (?prefLabel AS ?deletedInstanceLabel)
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters


### PR DESCRIPTION
- rename Property Group to Category
- rename instance to resource
- rename prefLabel to label (likewise prefLabelLang to labelLang)
- remove redundant actionType
- remove redundant Class column (the section already names it)