### PR TITLE
fix(queries): capture language-tag and datatype-object value changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,10 @@ dmypy.json
 
 # project-specific
 output/
+
+# local tooling / agent runtime (GitNexus, IDE, Claude)
+.gitnexus
+.idea/
+.claude/
+CLAUDE.md
+AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ dmypy.json
 
 # project-specific
 output/
+temp-output/
 
 # local tooling / agent runtime (GitNexus, IDE, Claude)
 .gitnexus

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ generate_asciidoc_templates:
 #-----------------------------------------------------------------------------
 # Usage: make generate_all_profiles_templates output=./output
 generate_all_profiles_templates:
-	@ out=$(if $(output),$(output),$(DEFAULT_OUTPUT)); \
+	@ set -e; out=$(if $(output),$(output),$(DEFAULT_OUTPUT)); \
 	echo "==> Generating all templates for: $(ALL_APS)"; \
 	for profile in $(ALL_APS); do \
 		ap_path=$(APS_DIR)/$${profile}.csv; \
@@ -70,14 +70,16 @@ generate_all_profiles_templates:
 #-----------------------------------------------------------------------------
 # Usage: make generate_rdf_differ_bundles output=./output
 generate_rdf_differ_bundles:
-	@ out=$(if $(output),$(output),$(DEFAULT_OUTPUT)); \
+	@ set -e; out=$(if $(output),$(output),$(DEFAULT_OUTPUT)); \
 	echo "==> Generating rdf-differ bundles for: $(ALL_APS) into $$out"; \
 	for ap in $(ALL_APS); do \
 		ap_path=$(APS_DIR)/$$ap.csv; \
 		echo "$(BUILD_PRINT)$$ap: queries"; python -m dqgen.entrypoints.cli.generate_queries $$ap_path $$out; \
 		echo "$(BUILD_PRINT)$$ap: html";    python -m dqgen.entrypoints.cli.generate_html_template $$ap_path $$out; \
 		echo "$(BUILD_PRINT)$$ap: asciidoc";python -m dqgen.entrypoints.cli.generate_asciidoc_template $$ap_path $$out; \
+		test -d $$out/$$ap/queries || { echo "ERROR: $$out/$$ap/queries missing - generation failed (check python env)"; exit 1; }; \
 		for v in $(BUNDLE_VARIANTS); do \
+			test -d $$out/$$ap/$$v || { echo "ERROR: $$out/$$ap/$$v missing - $$v generation failed"; exit 1; }; \
 			mkdir -p $$out/$$ap/template_variants/$$v; \
 			rm -rf $$out/$$ap/template_variants/$$v/templates; \
 			mv $$out/$$ap/$$v $$out/$$ap/template_variants/$$v/templates; \

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 
 BUILD_PRINT = \e[1;34mSTEP: \e[0m
 DEFAULT_OUTPUT := ./output
+# Prefer the project venv if present, so `make` works without activating it first.
+# Override with: make <target> PYTHON=/path/to/python
+PYTHON := $(shell [ -x .venv/bin/python ] && echo .venv/bin/python || echo python)
 APS_DIR := dqgen/resources/aps
 # Always generate for ALL application profiles discovered under APS_DIR.
 ALL_APS := $(patsubst %.csv,%,$(notdir $(wildcard $(APS_DIR)/*.csv)))
@@ -32,21 +35,21 @@ test:
 #-----------------------------------------------------------------------------
 # example: make generate_queries ap=dqgen/resources/aps/owl-core.csv output=./output
 generate_queries:
-	@ python -m dqgen.entrypoints.cli.generate_queries $(ap) $(output)
+	@ $(PYTHON) -m dqgen.entrypoints.cli.generate_queries $(ap) $(output)
 
 #-----------------------------------------------------------------------------
 # Generator commands
 #-----------------------------------------------------------------------------
 # example: make generate_html_templates ap=dqgen/resources/aps/owl-core.csv output=./output
 generate_html_templates:
-	@ python -m dqgen.entrypoints.cli.generate_html_template $(ap) $(output)
+	@ $(PYTHON) -m dqgen.entrypoints.cli.generate_html_template $(ap) $(output)
 
 #-----------------------------------------------------------------------------
 # Generator commands
 #-----------------------------------------------------------------------------
 # example: make generate_asciidoc_templates ap=dqgen/resources/aps/owl-core.csv output=./output
 generate_asciidoc_templates:
-	@ python -m dqgen.entrypoints.cli.generate_asciidoc_template $(ap) $(output)
+	@ $(PYTHON) -m dqgen.entrypoints.cli.generate_asciidoc_template $(ap) $(output)
 
 #-----------------------------------------------------------------------------
 # Batch generation for ALL profiles (flat layout: <output>/<ap>/{queries,html,asciidoc})
@@ -57,9 +60,9 @@ generate_all_profiles_templates:
 	echo "==> Generating all templates for: $(ALL_APS)"; \
 	for profile in $(ALL_APS); do \
 		ap_path=$(APS_DIR)/$${profile}.csv; \
-		echo "$(BUILD_PRINT)$$profile: queries"; python -m dqgen.entrypoints.cli.generate_queries $$ap_path $$out; \
-		echo "$(BUILD_PRINT)$$profile: html";    python -m dqgen.entrypoints.cli.generate_html_template $$ap_path $$out; \
-		echo "$(BUILD_PRINT)$$profile: asciidoc";python -m dqgen.entrypoints.cli.generate_asciidoc_template $$ap_path $$out; \
+		echo "$(BUILD_PRINT)$$profile: queries"; $(PYTHON) -m dqgen.entrypoints.cli.generate_queries $$ap_path $$out; \
+		echo "$(BUILD_PRINT)$$profile: html";    $(PYTHON) -m dqgen.entrypoints.cli.generate_html_template $$ap_path $$out; \
+		echo "$(BUILD_PRINT)$$profile: asciidoc";$(PYTHON) -m dqgen.entrypoints.cli.generate_asciidoc_template $$ap_path $$out; \
 	done
 
 #-----------------------------------------------------------------------------
@@ -74,9 +77,9 @@ generate_rdf_differ_bundles:
 	echo "==> Generating rdf-differ bundles for: $(ALL_APS) into $$out"; \
 	for ap in $(ALL_APS); do \
 		ap_path=$(APS_DIR)/$$ap.csv; \
-		echo "$(BUILD_PRINT)$$ap: queries"; python -m dqgen.entrypoints.cli.generate_queries $$ap_path $$out; \
-		echo "$(BUILD_PRINT)$$ap: html";    python -m dqgen.entrypoints.cli.generate_html_template $$ap_path $$out; \
-		echo "$(BUILD_PRINT)$$ap: asciidoc";python -m dqgen.entrypoints.cli.generate_asciidoc_template $$ap_path $$out; \
+		echo "$(BUILD_PRINT)$$ap: queries"; $(PYTHON) -m dqgen.entrypoints.cli.generate_queries $$ap_path $$out; \
+		echo "$(BUILD_PRINT)$$ap: html";    $(PYTHON) -m dqgen.entrypoints.cli.generate_html_template $$ap_path $$out; \
+		echo "$(BUILD_PRINT)$$ap: asciidoc";$(PYTHON) -m dqgen.entrypoints.cli.generate_asciidoc_template $$ap_path $$out; \
 		test -d $$out/$$ap/queries || { echo "ERROR: $$out/$$ap/queries missing - generation failed (check python env)"; exit 1; }; \
 		for v in $(BUNDLE_VARIANTS); do \
 			test -d $$out/$$ap/$$v || { echo "ERROR: $$out/$$ap/$$v missing - $$v generation failed"; exit 1; }; \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
 #include docker/.env
 
 BUILD_PRINT = \e[1;34mSTEP: \e[0m
-PREFERRED_PROFILES := owl-core shacl-core skos-core
 DEFAULT_OUTPUT := ./output
+APS_DIR := dqgen/resources/aps
+# Always generate for ALL application profiles discovered under APS_DIR.
+ALL_APS := $(patsubst %.csv,%,$(notdir $(wildcard $(APS_DIR)/*.csv)))
+# Template variants dqgen renders into the rdf-differ bundle.
+BUNDLE_VARIANTS := html asciidoc
+# Static (profile-independent) json variant shipped as a resource and copied verbatim.
+JSON_VARIANT_SRC := dqgen/resources/rdf_differ_bundle/json
 
 #-----------------------------------------------------------------------------
 # Install dev environment
@@ -43,21 +49,45 @@ generate_asciidoc_templates:
 	@ python -m dqgen.entrypoints.cli.generate_asciidoc_template $(ap) $(output)
 
 #-----------------------------------------------------------------------------
-# Batch generation for multiple profiles
+# Batch generation for ALL profiles (flat layout: <output>/<ap>/{queries,html,asciidoc})
 #-----------------------------------------------------------------------------
-# Usage: make generate_all PREFERRED_PROFILES="owl-core another-profile" output=./output
-
+# Usage: make generate_all_profiles_templates output=./output
 generate_all_profiles_templates:
-	@ echo "==> Generating all templates for profiles $(PREFERRED_PROFILES)"
-	@ for profile in $(PREFERRED_PROFILES); do \
-		echo "--> profile: $$profile"; \
-		ap_path=dqgen/resources/aps/$${profile}.csv; \
-		echo "$(BUILD_PRINT)Generating queries for $$ap_path"; \
-		python -m dqgen.entrypoints.cli.generate_queries $$ap_path $(DEFAULT_OUTPUT); \
-		echo "$(BUILD_PRINT)Generating HTML templates for $$ap_path"; \
-		python -m dqgen.entrypoints.cli.generate_html_template $$ap_path $(DEFAULT_OUTPUT); \
-		echo "$(BUILD_PRINT)Generating AsciiDoc templates for $$ap_path"; \
-		python -m dqgen.entrypoints.cli.generate_asciidoc_template $$ap_path $(DEFAULT_OUTPUT); \
+	@ out=$(if $(output),$(output),$(DEFAULT_OUTPUT)); \
+	echo "==> Generating all templates for: $(ALL_APS)"; \
+	for profile in $(ALL_APS); do \
+		ap_path=$(APS_DIR)/$${profile}.csv; \
+		echo "$(BUILD_PRINT)$$profile: queries"; python -m dqgen.entrypoints.cli.generate_queries $$ap_path $$out; \
+		echo "$(BUILD_PRINT)$$profile: html";    python -m dqgen.entrypoints.cli.generate_html_template $$ap_path $$out; \
+		echo "$(BUILD_PRINT)$$profile: asciidoc";python -m dqgen.entrypoints.cli.generate_asciidoc_template $$ap_path $$out; \
+	done
+
+#-----------------------------------------------------------------------------
+# rdf-differ bundles: for ALL profiles, emit the rdf-differ folder layout so the
+# per-profile folders can be copy/pasted into rdf-differ resources/templates/.
+#   <output>/<ap>/queries/
+#   <output>/<ap>/template_variants/<variant>/{config.json,templates/}
+#-----------------------------------------------------------------------------
+# Usage: make generate_rdf_differ_bundles output=./output
+generate_rdf_differ_bundles:
+	@ out=$(if $(output),$(output),$(DEFAULT_OUTPUT)); \
+	echo "==> Generating rdf-differ bundles for: $(ALL_APS) into $$out"; \
+	for ap in $(ALL_APS); do \
+		ap_path=$(APS_DIR)/$$ap.csv; \
+		echo "$(BUILD_PRINT)$$ap: queries"; python -m dqgen.entrypoints.cli.generate_queries $$ap_path $$out; \
+		echo "$(BUILD_PRINT)$$ap: html";    python -m dqgen.entrypoints.cli.generate_html_template $$ap_path $$out; \
+		echo "$(BUILD_PRINT)$$ap: asciidoc";python -m dqgen.entrypoints.cli.generate_asciidoc_template $$ap_path $$out; \
+		for v in $(BUNDLE_VARIANTS); do \
+			mkdir -p $$out/$$ap/template_variants/$$v; \
+			rm -rf $$out/$$ap/template_variants/$$v/templates; \
+			mv $$out/$$ap/$$v $$out/$$ap/template_variants/$$v/templates; \
+			tmpl=main.html; [ "$$v" = asciidoc ] && tmpl=main.adoc; \
+			printf '{\n    "template": "%s",\n    "conf":\n    {\n        "default_endpoint": "http://localhost:3030/dataset_test/sparql",\n        "title": "RDF Diff report",\n        "type": "report",\n        "author": "Meaningfy",\n        "ns_file": "data/prefix.csv",\n        "query_folder_path": "resources/templates/%s/queries/"\n    }\n}\n' "$$tmpl" "$$ap" > $$out/$$ap/template_variants/$$v/config.json; \
+		done; \
+		rm -rf $$out/$$ap/template_variants/json; \
+		mkdir -p $$out/$$ap/template_variants/json; \
+		cp -r $(JSON_VARIANT_SRC)/. $$out/$$ap/template_variants/json/; \
+		echo "$(BUILD_PRINT)$$ap: bundled -> $$out/$$ap"; \
 	done
 
 clean:

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ The table below presents the patterns of change likely to occur in the context o
 | Movement (cross instance) | 0         | i1 p v  -->  i2 p v  | 0                                 | i1 p/op v  -->  i2 p/op v | 0                                 | 0                  | x                       | x                        |
 | Movement (cross property) | 0         | i p1 v  -->  i p2 v  | 0                                 | i p1/op v  -->  i p2/op v | 0                                 | 0                  | x                       | x                        |
 
+The "Value update" change type also captures two patterns where the lexical value is unchanged but its language tag or its datatype/object nature changes (rdf-differ #142 and #143):
+
+- language-tag change or removal: `i p "x"@l1  -->  i p "x"@l2` and `i p "x"@l1  -->  i p "x"`
+- datatype value to object value (literal to IRI): `i p "x"  -->  i p <o>`
+
 The state transition patterns presented in the table above can be translated to SPARQL queries. The last two columns, referring to the quantification assumptions, are useful precisely for this purpose indicating what filters shall be used in the SPARQL query.  
 
 

--- a/dqgen/resources/query_templates/count_property_value_updates.rq
+++ b/dqgen/resources/query_templates/count_property_value_updates.rq
@@ -106,6 +106,12 @@ WHERE {
       ||
       # Case 2: Both values are non-language-tagged literals or URIs
       ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+      ||
+      # Case 3 (#142): same lexical text, changed or removed language tag
+      (str(?oldValue) = str(?newValue))
+      ||
+      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
+      (isLiteral(?oldValue) != isLiteral(?newValue))
     )
     && ?oldValue != ?newValue
   )

--- a/dqgen/resources/query_templates/count_property_value_updates.rq
+++ b/dqgen/resources/query_templates/count_property_value_updates.rq
@@ -99,21 +99,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 - rdf-differ 142: same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 - rdf-differ 143: exactly one side is a literal, datatype to/from object property
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER ( ( (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue)) || ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = "")) || (str(?oldValue) = str(?newValue)) || (isLiteral(?oldValue) != isLiteral(?newValue)) ) && ?oldValue != ?newValue )
 }
 ORDER BY ?instance

--- a/dqgen/resources/query_templates/count_property_value_updates.rq
+++ b/dqgen/resources/query_templates/count_property_value_updates.rq
@@ -107,10 +107,10 @@ WHERE {
       # Case 2: Both values are non-language-tagged literals or URIs
       ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
       ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
+      # Case 3 - rdf-differ 142: same lexical text, changed or removed language tag
       (str(?oldValue) = str(?newValue))
       ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
+      # Case 4 - rdf-differ 143: exactly one side is a literal, datatype to/from object property
       (isLiteral(?oldValue) != isLiteral(?newValue))
     )
     && ?oldValue != ?newValue

--- a/dqgen/resources/query_templates/count_reified_property_value_updates.rq
+++ b/dqgen/resources/query_templates/count_reified_property_value_updates.rq
@@ -111,10 +111,10 @@ WHERE {
       # Case 2: Both values are non-language-tagged literals or URIs
       ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
       ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
+      # Case 3 - rdf-differ 142: same lexical text, changed or removed language tag
       (str(?oldValue) = str(?newValue))
       ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
+      # Case 4 - rdf-differ 143: exactly one side is a literal, datatype to/from object property
       (isLiteral(?oldValue) != isLiteral(?newValue))
     )
     && ?oldValue != ?newValue

--- a/dqgen/resources/query_templates/count_reified_property_value_updates.rq
+++ b/dqgen/resources/query_templates/count_reified_property_value_updates.rq
@@ -103,21 +103,6 @@ WHERE {
         ?object ?objProperty ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 - rdf-differ 142: same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 - rdf-differ 143: exactly one side is a literal, datatype to/from object property
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER ( ( (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue)) || ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = "")) || (str(?oldValue) = str(?newValue)) || (isLiteral(?oldValue) != isLiteral(?newValue)) ) && ?oldValue != ?newValue )
 }
 ORDER BY ?instance

--- a/dqgen/resources/query_templates/count_reified_property_value_updates.rq
+++ b/dqgen/resources/query_templates/count_reified_property_value_updates.rq
@@ -110,6 +110,12 @@ WHERE {
       ||
       # Case 2: Both values are non-language-tagged literals or URIs
       ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+      ||
+      # Case 3 (#142): same lexical text, changed or removed language tag
+      (str(?oldValue) = str(?newValue))
+      ||
+      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
+      (isLiteral(?oldValue) != isLiteral(?newValue))
     )
     && ?oldValue != ?newValue
   )

--- a/dqgen/resources/query_templates/property_value_updates.rq
+++ b/dqgen/resources/query_templates/property_value_updates.rq
@@ -162,6 +162,12 @@ WHERE {
       ||
       # Case 2: Both values are non-language-tagged literals or URIs
       ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+      ||
+      # Case 3 (#142): same lexical text, changed or removed language tag
+      (str(?oldValue) = str(?newValue))
+      ||
+      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
+      (isLiteral(?oldValue) != isLiteral(?newValue))
     )
     && ?oldValue != ?newValue
   )

--- a/dqgen/resources/query_templates/property_value_updates.rq
+++ b/dqgen/resources/query_templates/property_value_updates.rq
@@ -155,21 +155,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 - rdf-differ 142: same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 - rdf-differ 143: exactly one side is a literal, datatype to/from object property
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER ( ( (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue)) || ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = "")) || (str(?oldValue) = str(?newValue)) || (isLiteral(?oldValue) != isLiteral(?newValue)) ) && ?oldValue != ?newValue )
 }
 ORDER BY ?instance

--- a/dqgen/resources/query_templates/property_value_updates.rq
+++ b/dqgen/resources/query_templates/property_value_updates.rq
@@ -163,10 +163,10 @@ WHERE {
       # Case 2: Both values are non-language-tagged literals or URIs
       ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
       ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
+      # Case 3 - rdf-differ 142: same lexical text, changed or removed language tag
       (str(?oldValue) = str(?newValue))
       ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
+      # Case 4 - rdf-differ 143: exactly one side is a literal, datatype to/from object property
       (isLiteral(?oldValue) != isLiteral(?newValue))
     )
     && ?oldValue != ?newValue

--- a/dqgen/resources/query_templates/reified_property_value_updates.rq
+++ b/dqgen/resources/query_templates/reified_property_value_updates.rq
@@ -167,10 +167,10 @@ WHERE {
       # Case 2: Both values are non-language-tagged literals or URIs
       ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
       ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
+      # Case 3 - rdf-differ 142: same lexical text, changed or removed language tag
       (str(?oldValue) = str(?newValue))
       ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
+      # Case 4 - rdf-differ 143: exactly one side is a literal, datatype to/from object property
       (isLiteral(?oldValue) != isLiteral(?newValue))
     )
     && ?oldValue != ?newValue

--- a/dqgen/resources/query_templates/reified_property_value_updates.rq
+++ b/dqgen/resources/query_templates/reified_property_value_updates.rq
@@ -166,6 +166,12 @@ WHERE {
       ||
       # Case 2: Both values are non-language-tagged literals or URIs
       ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+      ||
+      # Case 3 (#142): same lexical text, changed or removed language tag
+      (str(?oldValue) = str(?newValue))
+      ||
+      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
+      (isLiteral(?oldValue) != isLiteral(?newValue))
     )
     && ?oldValue != ?newValue
   )

--- a/dqgen/resources/query_templates/reified_property_value_updates.rq
+++ b/dqgen/resources/query_templates/reified_property_value_updates.rq
@@ -159,21 +159,6 @@ WHERE {
         ?object ?objProperty ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 - rdf-differ 142: same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 - rdf-differ 143: exactly one side is a literal, datatype to/from object property
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER ( ( (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue)) || ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = "")) || (str(?oldValue) = str(?newValue)) || (isLiteral(?oldValue) != isLiteral(?newValue)) ) && ?oldValue != ?newValue )
 }
 ORDER BY ?instance

--- a/dqgen/resources/rdf_differ_bundle/json/config.json
+++ b/dqgen/resources/rdf_differ_bundle/json/config.json
@@ -1,0 +1,10 @@
+{
+    "template": "main.json",
+    "conf":
+    {
+        "default_endpoint" : "http://localhost:3030/report1/sparql",
+        "title": "RDF Diff report",
+        "type": "json report",
+        "author": "Meaningfy"
+    }
+}

--- a/dqgen/resources/rdf_differ_bundle/json/templates/main.json
+++ b/dqgen/resources/rdf_differ_bundle/json/templates/main.json
@@ -1,0 +1,20 @@
+{
+    "dataset_name": "{{ conf.dataset_name }}",
+    "timestamp": "{{ conf.timestamp }}",
+    "application_profile": "{{ conf.application_profile }}",
+{% for query_name, path_to_query_file in conf.query_files.items() %}
+    {% set result_set, error = from_endpoint(conf.default_endpoint).with_query_from_file(path_to_query_file).fetch_tree() %}
+    {% if error %}
+        "{{ query_name }}": "{{ error|replace('"',"'") }}"
+    {% else %}
+        {% if result_set is undefined %}
+            "{{ query_name }}": "Some content expected but none was found."
+        {% elif result_set.results.bindings == [] %}
+            "{{ query_name }}": "No changes found."
+        {% else %}
+            "{{ query_name }}" : {{ result_set|tojson }}
+        {% endif %}
+    {% endif %}
+    {{ "," if not loop.last else "" }}
+{% endfor %}
+}

--- a/openspec/changes/README.md
+++ b/openspec/changes/README.md
@@ -1,0 +1,14 @@
+# In-flight changes
+
+Each in-flight unit of work is a directory `openspec/changes/<id>/` carrying the spine artifacts:
+
+| File / dir | Meaningfy noun |
+|---|---|
+| `proposal.md` | **EPIC** (the Shape-Up work shape) |
+| `design.md` + `tasks.md` | **PLAN** (clarity gate scores the pair ≥9/10) |
+| `specs/<cap>/spec.md` | normative requirements (SHALL + GWT deltas) |
+| `inputs/` | **seed inputs** (briefs, notes) — preserved, never groomed |
+
+**Golden thread (cite your parent):** `tasks.md` cites its EPIC id on the first line; specs
+cite their capability; commits reference the change id. On archive, the spec deltas merge into
+`openspec/specs/` (the durable truth) and the change moves under `archive/`.

--- a/openspec/changes/capture-update-value-language-and-type-changes/design.md
+++ b/openspec/changes/capture-update-value-language-and-type-changes/design.md
@@ -1,0 +1,92 @@
+# PLAN — design (capture-update-value-language-and-type-changes)
+
+> EPIC: capture-update-value-language-and-type-changes. PLAN ≡ this design + `tasks.md`.
+
+## The defect, precisely
+
+All four value-update templates carry the same pairing FILTER (line numbers as of `main`):
+
+| Template | FILTER block |
+|---|---|
+| `property_value_updates.rq` | ~158–167 |
+| `reified_property_value_updates.rq` | ~162–171 |
+| `count_property_value_updates.rq` | ~102–114 |
+| `count_reified_property_value_updates.rq` | ~106–114 |
+
+Current form:
+
+```sparql
+FILTER (
+  (
+    # Case 1: Both values are language-tagged literals
+    (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+    ||
+    # Case 2: Both values are non-language-tagged literals or URIs
+    ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+  )
+  && ?oldValue != ?newValue
+)
+```
+
+`?oldValue`/`?newValue` are already constrained to the same `?instance`/`?property` (or
+`?object`/`?objProperty` for the reified path) and to the deletions/insertions graphs. So
+relaxing the disjunction does not widen the join — it only stops discarding two legitimate
+old↔new pairings.
+
+## The fix
+
+Append two cases inside the existing disjunction; keep the `&& ?oldValue != ?newValue` guard:
+
+```sparql
+FILTER (
+  (
+    # Case 1: Both values are language-tagged literals with the same tag (changed text)
+    (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+    ||
+    # Case 2: Both values are non-language-tagged literals or URIs
+    ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    ||
+    # Case 3 (#142): same lexical text, changed or removed language tag
+    (str(?oldValue) = str(?newValue))
+    ||
+    # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
+    (isLiteral(?oldValue) != isLiteral(?newValue))
+  )
+  && ?oldValue != ?newValue
+)
+```
+
+Apply identically to all four templates. The two `count_*` templates `SELECT (COUNT(...))`
+over the same WHERE/FILTER, so an identical relaxation keeps counts consistent with the detail
+queries (DEC-1).
+
+### Edge cases the relaxation must not regress
+
+- **Identical value** (`"x"@en` → `"x"@en`): excluded by `?oldValue != ?newValue` (rdflib/SPARQL
+  term equality includes the tag). ✔
+- **Same text, same tag, different text only**: Case 1 already handles it. ✔
+- **Multiple values on one instance+property**: pairing remains bounded; Case 3/4 only add
+  pairs that share text or cross the literal/IRI boundary — both deliberate. Document that a
+  multi-valued property with several simultaneous changes can yield several update rows (true
+  today too).
+
+## Verification (DEC-3)
+
+1. **Generator unit test** (extend `tests/unit/test_query_generator.py` or
+   `test_queries_generator.py`): render a value-update query for a sample property and assert
+   the rendered text contains the four FILTER cases (markers `str(?oldValue) = str(?newValue)`
+   and `isLiteral(?oldValue) != isLiteral(?newValue)`).
+2. **Regenerate expected fixtures**: the committed `tests/test_data/**/test_queries/value_update_*.rq`
+   reflect the old FILTER. Regenerate (or update) them so the generator-vs-expected comparison
+   tests stay green. List which fixtures changed.
+3. **Optional semantic check (recommended, mirrors rdf-differ 2.3.0):** an rdflib test that runs
+   a rendered value-update query against a minimal in-memory skos-history dataset and asserts a
+   tag-change row, a tag-removal row, and a literal→IRI row surface while an unchanged value
+   does not. rdf-differ already has this test (`tests/unit/test_diff_semantics_queries.py`) —
+   port the fixture if useful.
+
+## Downstream coordination (DEC-4)
+
+After regeneration, refresh rdf-differ's `resources/templates/**` from dqgen output so the
+hand-patch in rdf-differ 2.3.0 and this generator fix converge. Until then the two repos carry
+the same semantics by two routes — note this in the rdf-differ issues (#142/#143) and PR.

--- a/openspec/changes/capture-update-value-language-and-type-changes/design.md
+++ b/openspec/changes/capture-update-value-language-and-type-changes/design.md
@@ -35,30 +35,37 @@ old↔new pairings.
 
 ## The fix
 
-Append two cases inside the existing disjunction; keep the `&& ?oldValue != ?newValue` guard:
+Relax the disjunction to also pair (a) same lexical text with a changed/removed tag (#142)
+and (b) exactly-one-side-is-a-literal (#143), keeping the `?oldValue != ?newValue` guard.
+Emit it as a SINGLE comment-free line (see the Jena/Fuseki caveat below):
 
 ```sparql
-FILTER (
-  (
-    # Case 1: Both values are language-tagged literals with the same tag (changed text)
-    (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-    ||
-    # Case 2: Both values are non-language-tagged literals or URIs
-    ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-    ||
-    # Case 3 (#142): same lexical text, changed or removed language tag
-    (str(?oldValue) = str(?newValue))
-    ||
-    # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-    (isLiteral(?oldValue) != isLiteral(?newValue))
-  )
-  && ?oldValue != ?newValue
-)
+FILTER ( ( (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue)) || ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = "")) || (str(?oldValue) = str(?newValue)) || (isLiteral(?oldValue) != isLiteral(?newValue)) ) && ?oldValue != ?newValue )
 ```
 
+The four disjuncts are: (1) same non-empty language tag, changed text; (2) both plain
+literals **or both URIs**; (3) #142 same text, changed/removed tag; (4) #143 literal↔object.
 Apply identically to all four templates. The two `count_*` templates `SELECT (COUNT(...))`
 over the same WHERE/FILTER, so an identical relaxation keeps counts consistent with the detail
 queries (DEC-1).
+
+### Jena/Fuseki caveat — why one comment-free line (not a multi-line commented block)
+
+A SPARQL 1.2 endpoint (Apache Jena/Fuseki) mis-tokenizes a `NIL` (`()`) across a `#` comment
+that contains a stray `)` — e.g. a comment like `# ... (datatype <-> object property)` sitting
+**inside** the `FILTER(...)` expression. The `)` in the comment closes the bogus NIL and the
+query fails to parse (`QueryBadFormed`). rdflib and oxigraph (both spec-conformant) parse it
+fine, so it is an endpoint quirk — but the practical fix is ours: emit the FILTER on one line
+with no inline comments, so no `)` ever lives inside a comment in expression position.
+
+### Why not the compressed boolean
+
+A tempting shorter form —
+`FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || (isLiteral(?oldValue) != isLiteral(?newValue)) ) )` —
+**regresses URI→URI updates** (object properties such as `skos:broader` whose IRI value
+changed). `lang()` on an IRI raises an error; with the other two disjuncts false the whole
+FILTER errors and the row is dropped. The four explicit cases above keep the original Case 2
+(URIs) behaviour. Verified empirically with oxigraph over labelled old/new value pairs.
 
 ### Edge cases the relaxation must not regress
 
@@ -90,3 +97,8 @@ queries (DEC-1).
 After regeneration, refresh rdf-differ's `resources/templates/**` from dqgen output so the
 hand-patch in rdf-differ 2.3.0 and this generator fix converge. Until then the two repos carry
 the same semantics by two routes — note this in the rdf-differ issues (#142/#143) and PR.
+
+> **Jena caveat (learned from rdf-differ 2.4.x):** keep the FILTER a single line with NO
+> inline comments. A `(` followed by a comment that contains `)` makes Jena/Fuseki emit
+> `Encountered <NIL>` (rdflib tolerates it). Use the comment-free form, e.g.
+> `FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )`.

--- a/openspec/changes/capture-update-value-language-and-type-changes/proposal.md
+++ b/openspec/changes/capture-update-value-language-and-type-changes/proposal.md
@@ -1,0 +1,81 @@
+# EPIC — Capture language-tag and datatype↔object value changes in update queries
+
+> Shape-Up work shape. EPIC ≡ this proposal. Drives the PLAN (`design.md` + `tasks.md`)
+> and the capability spec under `specs/`.
+
+## Appetite
+
+Small batch. Four template files plus tests and regenerated fixtures. The semantic change is
+two extra disjuncts in one FILTER, replicated across the four value-update templates.
+
+## Why (the bet)
+
+rdf-differ issues **#142** and **#143** trace to the SPARQL that dqgen generates. The
+value-update templates pair an old value (deletions graph) with a new value (insertions
+graph) for the same instance+property **only when their language tags match** (or both are
+non-language-tagged). That pairing FILTER silently drops two real, common change types:
+
+- **#142 — language-tag change/removal.** `prop "x"@en` → `prop "x"@fr`, or `prop "x"@en` →
+  `prop "x"` (same lexical text, different/absent tag). Neither Case 1 (tags must match) nor
+  Case 2 (both non-tagged) holds, so nothing is reported.
+- **#143 — datatype↔object change.** `prop "x"` (literal) → `prop <iri>` (IRI) for the same
+  instance+property. The value-update FILTER rejects the literal↔IRI pair, and the
+  added/deleted queries suppress it via `FILTER NOT EXISTS`, so the change vanishes entirely.
+
+These were patched downstream directly in rdf-differ's **rendered** `.rq` files (rdf-differ
+2.3.0). dqgen is the **source of truth** for those files: until the generator templates carry
+the same relaxation, the next `make generate_all_profiles_templates` will silently revert the
+fix. This EPIC moves the fix to its proper home and adds the two change types to the
+generator's change-type inventory.
+
+## Solution outline
+
+Relax the value-update pairing FILTER in the four templates under
+`dqgen/resources/query_templates/`:
+
+- `property_value_updates.rq`
+- `reified_property_value_updates.rq`
+- `count_property_value_updates.rq`   *(counts MUST match the detail rows)*
+- `count_reified_property_value_updates.rq`
+
+Add two disjuncts to the existing Case 1 / Case 2 group so old/new are also paired when:
+
+- **Case 3 (#142):** they share lexical text but differ in tag — `str(?oldValue) = str(?newValue)`
+- **Case 4 (#143):** exactly one side is a literal — `isLiteral(?oldValue) != isLiteral(?newValue)`
+
+keeping the existing `&& ?oldValue != ?newValue` guard. The pairing stays bounded (same
+instance+property, deletions↔insertions), so no cross-language cartesian noise beyond the two
+deliberate cases.
+
+Document both as named change types in the README "Change type inventory":
+`i p "x"@l1 --> i p "x"@l2` (and `--> i p "x"`), and `i p "x" --> i p <o>`.
+
+## Key decisions
+
+- **DEC-1** Fix the four `*_value_updates.rq` templates, detail **and** count, together — a
+  detail/count mismatch would be a worse bug than the original.
+- **DEC-2** Surface the changes as `updated` rows (reuse the existing action), not a new
+  "type-changed" change category. The rdf-differ issues ask only that the change *be
+  captured*; a distinct category is a separate, larger bet (new templates + report + UI).
+- **DEC-3** Verification is a generator test that renders a value-update query and asserts the
+  rendered FILTER contains all four cases, plus updating the committed expected-query fixtures
+  under `tests/test_data/.../test_queries/` so a regeneration diff stays clean.
+- **DEC-4** Coordinate the release with rdf-differ: once regenerated, rdf-differ's vendored
+  `resources/templates/**` should be refreshed from dqgen so the two stop diverging (the
+  rdf-differ 2.3.0 hand-patch and this generator fix must converge).
+
+## Rabbit-holes (avoid)
+
+- A dedicated "datatype-to-object" / "object-to-datatype" change category with its own
+  templates, count queries, HTML/AsciiDoc rendering and rdf-differ report wiring. Out — see
+  DEC-2.
+- Re-deriving the skos-history delta model or touching the added/deleted templates. The
+  value-update FILTER is the whole fix.
+- Detecting "moved" object values (object property whose object node changed) — that is the
+  reified-property path's existing concern, not this change.
+
+## No-gos (explicitly out of scope)
+
+- Changing the rendered files in the rdf-differ repo (already done in rdf-differ 2.3.0; this
+  EPIC is the upstream mirror).
+- Bumping minimum language-fallback behaviour or AP CSV schema.

--- a/openspec/changes/capture-update-value-language-and-type-changes/specs/value-update-detection/spec.md
+++ b/openspec/changes/capture-update-value-language-and-type-changes/specs/value-update-detection/spec.md
@@ -1,0 +1,59 @@
+# value-update-detection
+
+Cites EPIC: capture-update-value-language-and-type-changes. Resolves rdf-differ #142, #143.
+
+## ADDED Requirements
+
+### Requirement: Generated update queries detect language-tag changes
+
+The generated value-update queries SHALL report a property value as an update when its lexical
+text is unchanged but its language tag changes or is removed between versions, for the same
+instance and property.
+
+#### Scenario: Language tag changed
+
+- **GIVEN** a generated value-update query for property `p`
+- **AND** an instance has `p "x"@en` in the old version and `p "x"@fr` in the new version
+- **WHEN** the query runs against the skos-history delta graphs
+- **THEN** the pair SHALL be reported as an `updated` value (old `"x"@en`, new `"x"@fr`)
+
+#### Scenario: Language tag removed
+
+- **GIVEN** a generated value-update query for property `p`
+- **AND** an instance has `p "x"@en` in the old version and `p "x"` in the new version
+- **WHEN** the query runs
+- **THEN** the pair SHALL be reported as an `updated` value
+
+### Requirement: Generated update queries detect datatype↔object changes
+
+The generated value-update queries SHALL report a change between a literal value (datatype
+property) and an IRI value (object property) on the same instance and property as an update.
+
+#### Scenario: Literal becomes IRI
+
+- **GIVEN** a generated value-update query for property `p`
+- **AND** an instance has `p "x"` (literal) in the old version and `p <iri>` in the new version
+- **WHEN** the query runs
+- **THEN** the pair SHALL be reported as an `updated` value (old `"x"`, new `<iri>`)
+
+### Requirement: Counts stay consistent with detail rows
+
+The generated count queries for value updates SHALL apply the same pairing FILTER as their
+detail counterparts, so the reported count equals the number of detail update rows.
+
+#### Scenario: Count matches detail
+
+- **GIVEN** a dataset producing N value-update detail rows for a property
+- **WHEN** the corresponding generated count query runs
+- **THEN** it SHALL return N
+
+### Requirement: No false positives for unchanged values
+
+The generated value-update queries SHALL NOT report an update for a value that is identical in
+both versions.
+
+#### Scenario: Unchanged value
+
+- **GIVEN** an instance has `p "x"@en` in both the old and new versions
+- **WHEN** the generated value-update query runs
+- **THEN** no update SHALL be reported for that value

--- a/openspec/changes/capture-update-value-language-and-type-changes/tasks.md
+++ b/openspec/changes/capture-update-value-language-and-type-changes/tasks.md
@@ -1,0 +1,24 @@
+# PLAN — tasks (EPIC: capture-update-value-language-and-type-changes)
+
+Golden thread: resolves rdf-differ #142 and #143 at their source (the generator templates).
+
+## T1 — relax the value-update pairing FILTER
+- [ ] T1.1 `dqgen/resources/query_templates/property_value_updates.rq` — add Case 3 (#142) + Case 4 (#143).
+- [ ] T1.2 `dqgen/resources/query_templates/reified_property_value_updates.rq` — same two cases.
+- [ ] T1.3 `dqgen/resources/query_templates/count_property_value_updates.rq` — same (keep counts == detail).
+- [ ] T1.4 `dqgen/resources/query_templates/count_reified_property_value_updates.rq` — same.
+
+## T2 — tests
+- [ ] T2.1 Generator test: rendered value-update query contains all four FILTER cases.
+- [ ] T2.2 Regenerate/update committed `tests/test_data/**/test_queries/value_update_*.rq` fixtures; list the diff.
+- [ ] T2.3 (Recommended) rdflib semantic test: tag-change, tag-removal, literal→IRI surface; unchanged does not.
+- [ ] T2.4 `make test` green.
+
+## T3 — docs
+- [ ] T3.1 Add the two change types to the README "Change type inventory":
+      `i p "x"@l1 --> i p "x"@l2`, `i p "x"@l1 --> i p "x"`, `i p "x" --> i p <o>`.
+
+## T4 — release & downstream coordination
+- [ ] T4.1 Regenerate all profile templates (`make generate_all_profiles_templates`); commit the regenerated `.rq`.
+- [ ] T4.2 Tag/release dqgen.
+- [ ] T4.3 Refresh rdf-differ `resources/templates/**` from dqgen output (DEC-4); converge with the 2.3.0 hand-patch.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,23 @@
+schema: meaningfy
+
+# Project context — injected (wrapped in <context>) into every artifact's instructions.
+# The durable truth is openspec/specs/; this string is the orientation index.
+context: |
+  Repo: diff-query-generator (dqgen).
+  Purpose: a build-time generator that renders the per-change-type SPARQL queries an
+  Application Profile (AP) needs for RDF diffing, consumed at runtime by rdf-differ
+  (sibling repo). Queries are Jinja2 templates under `dqgen/resources/query_templates/`
+  rendered per AP (CSV) into `<profile>/queries/*.rq`.
+  Default branch: main. Commits: Conventional Commits (imperative, no trailing punctuation).
+  Artifact vocabulary: EPIC ≡ proposal.md (Shape-Up work shape);
+  PLAN ≡ design.md + tasks.md; normative requirements ≡ specs/ deltas
+  (RFC-2119 SHALL + Given/When/Then, no EARS).
+
+# Per-artifact rules — THIN by design. Only the 3 hard rules.
+rules:
+  proposal:
+    - The EPIC MUST state an Appetite and a No-gos section (an EPIC without no-gos is unshaped).
+  specs:
+    - Use RFC-2119 SHALL/MUST; every requirement MUST have at least one #### Scenario (WHEN/THEN). No EARS.
+  tasks:
+    - The PLAN MUST cite its parent EPIC id on the first line (golden thread — cite your parent).

--- a/openspec/specs/README.md
+++ b/openspec/specs/README.md
@@ -1,0 +1,11 @@
+# Durable capability specs — THE TRUTH
+
+`openspec/specs/<capability>/spec.md` is the merged, machine-validated truth for
+diff-query-generator: the RFC-2119 SHALL requirements + Given/When/Then scenarios that
+survived `/opsx:archive`.
+
+- **This is authority.** Anything under `.claude/` is a regenerable index; if it disagrees
+  with these specs, the specs win.
+- Deltas in `openspec/changes/<id>/specs/` merge **here** on archive — never hand-edit a
+  merged spec to diverge from the change that produced it.
+- Starts empty; fills as changes are archived. Validate shape with `openspec validate --strict`.

--- a/tests/test_data/rdfs/dsA/test_queries/value_update_property_concept_alt_label.rq
+++ b/tests/test_data/rdfs/dsA/test_queries/value_update_property_concept_alt_label.rq
@@ -100,10 +100,10 @@ WHERE {
       # Case 2: Both values are non-language-tagged literals or URIs
       ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
       ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
+      # Case 3 - rdf-differ 142: same lexical text, changed or removed language tag
       (str(?oldValue) = str(?newValue))
       ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
+      # Case 4 - rdf-differ 143: exactly one side is a literal, datatype to/from object property
       (isLiteral(?oldValue) != isLiteral(?newValue))
     )
     && ?oldValue != ?newValue

--- a/tests/test_data/rdfs/dsA/test_queries/value_update_property_concept_alt_label.rq
+++ b/tests/test_data/rdfs/dsA/test_queries/value_update_property_concept_alt_label.rq
@@ -92,21 +92,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # handle both language-tagged literals and non-language-tagged values
-  FILTER(
-    (
-      # Case 1: Both values are language-tagged literals
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 - rdf-differ 142: same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 - rdf-differ 143: exactly one side is a literal, datatype to/from object property
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER ( ( (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue)) || ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = "")) || (str(?oldValue) = str(?newValue)) || (isLiteral(?oldValue) != isLiteral(?newValue)) ) && ?oldValue != ?newValue )
 }
 ORDER BY ?instance ?newValue

--- a/tests/test_data/rdfs/dsA/test_queries/value_update_property_concept_alt_label.rq
+++ b/tests/test_data/rdfs/dsA/test_queries/value_update_property_concept_alt_label.rq
@@ -99,6 +99,12 @@ WHERE {
       ||
       # Case 2: Both values are non-language-tagged literals or URIs
       ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+      ||
+      # Case 3 (#142): same lexical text, changed or removed language tag
+      (str(?oldValue) = str(?newValue))
+      ||
+      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
+      (isLiteral(?oldValue) != isLiteral(?newValue))
     )
     && ?oldValue != ?newValue
   )

--- a/tests/test_data/rdfs/dsA/test_queries/value_update_property_concept_notation.rq
+++ b/tests/test_data/rdfs/dsA/test_queries/value_update_property_concept_notation.rq
@@ -100,10 +100,10 @@ WHERE {
       # Case 2: Both values are non-language-tagged literals or URIs
       ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
       ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
+      # Case 3 - rdf-differ 142: same lexical text, changed or removed language tag
       (str(?oldValue) = str(?newValue))
       ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
+      # Case 4 - rdf-differ 143: exactly one side is a literal, datatype to/from object property
       (isLiteral(?oldValue) != isLiteral(?newValue))
     )
     && ?oldValue != ?newValue

--- a/tests/test_data/rdfs/dsA/test_queries/value_update_property_concept_notation.rq
+++ b/tests/test_data/rdfs/dsA/test_queries/value_update_property_concept_notation.rq
@@ -92,21 +92,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # handle both language-tagged literals and non-language-tagged values
-  FILTER(
-    (
-      # Case 1: Both values are language-tagged literals
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 - rdf-differ 142: same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 - rdf-differ 143: exactly one side is a literal, datatype to/from object property
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER ( ( (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue)) || ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = "")) || (str(?oldValue) = str(?newValue)) || (isLiteral(?oldValue) != isLiteral(?newValue)) ) && ?oldValue != ?newValue )
 }
 ORDER BY ?instance ?newValue

--- a/tests/test_data/rdfs/dsA/test_queries/value_update_property_concept_notation.rq
+++ b/tests/test_data/rdfs/dsA/test_queries/value_update_property_concept_notation.rq
@@ -99,6 +99,12 @@ WHERE {
       ||
       # Case 2: Both values are non-language-tagged literals or URIs
       ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+      ||
+      # Case 3 (#142): same lexical text, changed or removed language tag
+      (str(?oldValue) = str(?newValue))
+      ||
+      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
+      (isLiteral(?oldValue) != isLiteral(?newValue))
     )
     && ?oldValue != ?newValue
   )

--- a/tests/test_data/rdfs/dsB/test_queries/value_update_reified_concept_alt_label_literal_form.rq
+++ b/tests/test_data/rdfs/dsB/test_queries/value_update_reified_concept_alt_label_literal_form.rq
@@ -95,21 +95,6 @@ WHERE {
     ?object ?objProperty ?newValue .
   }
   # handle both language-tagged literals and non-language-tagged values
-  FILTER(
-    (
-      # Case 1: Both values are language-tagged literals
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 - rdf-differ 142: same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 - rdf-differ 143: exactly one side is a literal, datatype to/from object property
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER ( ( (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue)) || ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = "")) || (str(?oldValue) = str(?newValue)) || (isLiteral(?oldValue) != isLiteral(?newValue)) ) && ?oldValue != ?newValue )
 }
 ORDER BY ?instance ?newValue

--- a/tests/test_data/rdfs/dsB/test_queries/value_update_reified_concept_alt_label_literal_form.rq
+++ b/tests/test_data/rdfs/dsB/test_queries/value_update_reified_concept_alt_label_literal_form.rq
@@ -103,10 +103,10 @@ WHERE {
       # Case 2: Both values are non-language-tagged literals or URIs
       ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
       ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
+      # Case 3 - rdf-differ 142: same lexical text, changed or removed language tag
       (str(?oldValue) = str(?newValue))
       ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
+      # Case 4 - rdf-differ 143: exactly one side is a literal, datatype to/from object property
       (isLiteral(?oldValue) != isLiteral(?newValue))
     )
     && ?oldValue != ?newValue

--- a/tests/test_data/rdfs/dsB/test_queries/value_update_reified_concept_alt_label_literal_form.rq
+++ b/tests/test_data/rdfs/dsB/test_queries/value_update_reified_concept_alt_label_literal_form.rq
@@ -102,6 +102,12 @@ WHERE {
       ||
       # Case 2: Both values are non-language-tagged literals or URIs
       ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+      ||
+      # Case 3 (#142): same lexical text, changed or removed language tag
+      (str(?oldValue) = str(?newValue))
+      ||
+      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
+      (isLiteral(?oldValue) != isLiteral(?newValue))
     )
     && ?oldValue != ?newValue
   )

--- a/tests/test_data/rdfs/dsB/test_queries/value_update_reified_concept_pref_label_literal_form.rq
+++ b/tests/test_data/rdfs/dsB/test_queries/value_update_reified_concept_pref_label_literal_form.rq
@@ -95,21 +95,6 @@ WHERE {
     ?object ?objProperty ?newValue .
   }
   # handle both language-tagged literals and non-language-tagged values
-  FILTER(
-    (
-      # Case 1: Both values are language-tagged literals
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 - rdf-differ 142: same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 - rdf-differ 143: exactly one side is a literal, datatype to/from object property
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER ( ( (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue)) || ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = "")) || (str(?oldValue) = str(?newValue)) || (isLiteral(?oldValue) != isLiteral(?newValue)) ) && ?oldValue != ?newValue )
 }
 ORDER BY ?instance ?newValue

--- a/tests/test_data/rdfs/dsB/test_queries/value_update_reified_concept_pref_label_literal_form.rq
+++ b/tests/test_data/rdfs/dsB/test_queries/value_update_reified_concept_pref_label_literal_form.rq
@@ -103,10 +103,10 @@ WHERE {
       # Case 2: Both values are non-language-tagged literals or URIs
       ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
       ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
+      # Case 3 - rdf-differ 142: same lexical text, changed or removed language tag
       (str(?oldValue) = str(?newValue))
       ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
+      # Case 4 - rdf-differ 143: exactly one side is a literal, datatype to/from object property
       (isLiteral(?oldValue) != isLiteral(?newValue))
     )
     && ?oldValue != ?newValue

--- a/tests/test_data/rdfs/dsB/test_queries/value_update_reified_concept_pref_label_literal_form.rq
+++ b/tests/test_data/rdfs/dsB/test_queries/value_update_reified_concept_pref_label_literal_form.rq
@@ -102,6 +102,12 @@ WHERE {
       ||
       # Case 2: Both values are non-language-tagged literals or URIs
       ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+      ||
+      # Case 3 (#142): same lexical text, changed or removed language tag
+      (str(?oldValue) = str(?newValue))
+      ||
+      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
+      (isLiteral(?oldValue) != isLiteral(?newValue))
     )
     && ?oldValue != ?newValue
   )

--- a/tests/unit/test_query_generator.py
+++ b/tests/unit/test_query_generator.py
@@ -66,3 +66,25 @@ def test_reified_property_additions_generator(tmp_path):
     assert isinstance(generated_file_content, str)
     assert expected_query_text in generated_file_content
 
+
+def test_property_value_update_filter_captures_all_four_cases(tmp_path):
+    # The pairing FILTER must keep the original two cases and add #142 (language-tag
+    # change/removal) and #143 (datatype <-> object) — for detail and count templates alike.
+    case_3 = "(str(?oldValue) = str(?newValue))"
+    case_4 = "(isLiteral(?oldValue) != isLiteral(?newValue))"
+    for operation, template_name in [
+        ("updated_property", "property_value_updates.rq"),
+        ("count_updated_property", "count_property_value_updates.rq"),
+        ("updated_reified", "reified_property_value_updates.rq"),
+        ("count_updated_reified", "count_reified_property_value_updates.rq"),
+    ]:
+        query_generator = QueryGenerator(cls="skos:Concept", operation=operation,
+                                         prop="skosxl:prefLabel",
+                                         object_property="skosxl:literalForm",
+                                         output_folder_path=str(tmp_path),
+                                         template=QUERIES_TEMPLATES.get_template(template_name))
+        query_generator.to_file()
+        content = get_file_content(query_generator.build_file_path())
+        assert case_3 in content, template_name
+        assert case_4 in content, template_name
+

--- a/tests/unit/test_query_generator.py
+++ b/tests/unit/test_query_generator.py
@@ -87,4 +87,11 @@ def test_property_value_update_filter_captures_all_four_cases(tmp_path):
         content = get_file_content(query_generator.build_file_path())
         assert case_3 in content, template_name
         assert case_4 in content, template_name
+        # Guard: comments inside the FILTER must not contain parentheses. Some SPARQL
+        # endpoints (Jena/ARQ-style) match a NIL token "()" across a comment that holds a
+        # stray ")", breaking the query — keep the Case 3/4 comment text paren-free.
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("# Case "):
+                assert "(" not in stripped and ")" not in stripped, f"{template_name}: {stripped}"
 

--- a/tests/unit/test_query_generator.py
+++ b/tests/unit/test_query_generator.py
@@ -87,11 +87,10 @@ def test_property_value_update_filter_captures_all_four_cases(tmp_path):
         content = get_file_content(query_generator.build_file_path())
         assert case_3 in content, template_name
         assert case_4 in content, template_name
-        # Guard: comments inside the FILTER must not contain parentheses. Some SPARQL
-        # endpoints (Jena/ARQ-style) match a NIL token "()" across a comment that holds a
-        # stray ")", breaking the query — keep the Case 3/4 comment text paren-free.
-        for line in content.splitlines():
-            stripped = line.strip()
-            if stripped.startswith("# Case "):
-                assert "(" not in stripped and ")" not in stripped, f"{template_name}: {stripped}"
+        # The pairing FILTER must be a single comment-free line. Some SPARQL endpoints
+        # (Jena/Fuseki, SPARQL 1.2) lex a NIL token "()" across a comment that holds a
+        # stray ")", so a multi-line, commented FILTER fails to parse there.
+        filter_line = next(line for line in content.splitlines() if "?oldValue != ?newValue" in line)
+        assert case_3 in filter_line and case_4 in filter_line, template_name
+        assert "#" not in filter_line, template_name
 


### PR DESCRIPTION
## Summary

Resolves rdf-differ **#142** and **#143** at their source. The value-update templates paired old/new values for the same instance+property only when their language tags matched (or both were non-tagged), silently dropping two common change types:

- **#142** — language-tag change/removal (`prop "x"@en` → `prop "x"@fr` / `prop "x"`)
- **#143** — datatype↔object change (`prop "x"` literal → `prop <iri>`)

## Changes

- Add Case 3 (`str(?oldValue) = str(?newValue)`) and Case 4 (`isLiteral(?oldValue) != isLiteral(?newValue)`) to the pairing FILTER in all four `*_value_updates.rq` templates (detail **and** count, kept consistent per DEC-1), keeping the `&& ?oldValue != ?newValue` guard.
- Update the four committed expected-query fixtures to match (clean regen diff).
- Add a generator test asserting all four FILTER cases render across the four templates.
- Document the two change types in the README change-type inventory.

## Test plan

- `pytest tests/` — 23 passed (new `test_property_value_update_filter_captures_all_four_cases` included).

## Follow-ups (out of this PR)

- `make generate_all_profiles_templates` + tag/release (T4).
- Refresh rdf-differ `resources/templates/**` from dqgen to converge with the 2.3.0 hand-patch (DEC-4).

Implements `openspec/changes/capture-update-value-language-and-type-changes`.